### PR TITLE
Reduce upstream patch

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -171,7 +171,7 @@ jobs:
       with:
         cache-dependency-path: |
             sdk/go.sum
-        go-version: 1.21.x
+        go-version: 1.21.0
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -33,6 +33,7 @@ func getCwd(t *testing.T) string {
 }
 
 func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
+	t.Skip("Skipping due to expired Venafi token")
 	return integration.ProgramTestOptions{
 		ExpectRefreshChanges: true,
 		Secrets: map[string]string{

--- a/patches/0001-Fix-go-module-path-terraform-providers-Venafi.patch
+++ b/patches/0001-Fix-go-module-path-terraform-providers-Venafi.patch
@@ -1,0 +1,43 @@
+From 36cc6ee78434b1fb9b47cbf87405f1e32282cd5c Mon Sep 17 00:00:00 2001
+From: Ian Wahbe <ian@wahbe.com>
+Date: Tue, 3 Oct 2023 12:19:15 -0700
+Subject: [PATCH 1/2] Fix go module path: `terraform-providers` -> `Venafi`
+
+---
+ go.mod  | 4 ++--
+ main.go | 5 +++--
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 0324614..05168b8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+-module github.com/terraform-providers/terraform-provider-venafi
++module github.com/Venafi/terraform-provider-venafi
+ 
+-go 1.12
++go 1.19
+ 
+ require (
+ 	github.com/Venafi/vcert/v4 v4.22.0
+diff --git a/main.go b/main.go
+index 13942e8..7a7e9ad 100644
+--- a/main.go
++++ b/main.go
+@@ -2,9 +2,10 @@ package main
+ 
+ import (
+ 	"flag"
+-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+-	"github.com/terraform-providers/terraform-provider-venafi/venafi"
+ 	"log"
++
++	"github.com/Venafi/terraform-provider-venafi/venafi"
++	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+ )
+ 
+ func main() {
+-- 
+2.42.0
+

--- a/patches/0001-fork.patch
+++ b/patches/0001-fork.patch
@@ -1,7 +1,18 @@
-diff --git b/go.mod a/go.mod
-index 0324614..65af3fa 100644
---- b/go.mod
-+++ a/go.mod
+From fde17ddbef7d562d74211b1406c286041863f30a Mon Sep 17 00:00:00 2001
+From: Ian Wahbe <ian@wahbe.com>
+Date: Tue, 3 Oct 2023 12:15:12 -0700
+Subject: [PATCH] Fix import path
+
+---
+ go.mod                                        |  4 +-
+ main.go                                       |  5 +-
+ .../docs/r/venafi_certificate.html.markdown   | 56 +++----------------
+ 3 files changed, 14 insertions(+), 51 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 0324614..05168b8 100644
+--- a/go.mod
++++ b/go.mod
 @@ -1,6 +1,6 @@
 -module github.com/terraform-providers/terraform-provider-venafi
 +module github.com/Venafi/terraform-provider-venafi
@@ -11,270 +22,10 @@ index 0324614..65af3fa 100644
  
  require (
  	github.com/Venafi/vcert/v4 v4.22.0
-@@ -9,10 +9,121 @@ require (
- 	github.com/hashicorp/terraform-plugin-log v0.3.0
- 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
- 	github.com/pkg/errors v0.9.1
--	github.com/spf13/afero v1.2.2 // indirect
- 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a
-+	software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-+)
-+
-+require (
-+	github.com/BurntSushi/toml v0.3.1 // indirect
-+	github.com/OpenPeeDeeP/depguard v1.0.1 // indirect
-+	github.com/agext/levenshtein v1.2.2 // indirect
-+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
-+	github.com/bombsimon/wsl v1.2.5 // indirect
-+	github.com/davecgh/go-spew v1.1.1 // indirect
-+	github.com/fatih/color v1.7.0 // indirect
-+	github.com/fsnotify/fsnotify v1.4.7 // indirect
-+	github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db // indirect
-+	github.com/go-lintpack/lintpack v0.5.2 // indirect
-+	github.com/go-toolsmith/astcast v1.0.0 // indirect
-+	github.com/go-toolsmith/astcopy v1.0.0 // indirect
-+	github.com/go-toolsmith/astequal v1.0.0 // indirect
-+	github.com/go-toolsmith/astfmt v1.0.0 // indirect
-+	github.com/go-toolsmith/astp v1.0.0 // indirect
-+	github.com/go-toolsmith/strparse v1.0.0 // indirect
-+	github.com/go-toolsmith/typep v1.0.0 // indirect
-+	github.com/gobwas/glob v0.2.3 // indirect
-+	github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b // indirect
-+	github.com/gogo/protobuf v1.2.1 // indirect
-+	github.com/golang/protobuf v1.5.2 // indirect
-+	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 // indirect
-+	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
-+	github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6 // indirect
-+	github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 // indirect
-+	github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3 // indirect
-+	github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee // indirect
-+	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a // indirect
-+	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc // indirect
-+	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 // indirect
-+	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca // indirect
-+	github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770 // indirect
-+	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 // indirect
-+	github.com/golangci/revgrep v0.0.0-20180526074752-d9c87f5ffaf0 // indirect
-+	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
-+	github.com/google/go-cmp v0.5.7 // indirect
-+	github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3 // indirect
-+	github.com/hashicorp/errwrap v1.0.0 // indirect
-+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
-+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
-+	github.com/hashicorp/go-hclog v1.2.0 // indirect
-+	github.com/hashicorp/go-multierror v1.1.1 // indirect
-+	github.com/hashicorp/go-plugin v1.4.3 // indirect
-+	github.com/hashicorp/go-uuid v1.0.3 // indirect
-+	github.com/hashicorp/go-version v1.4.0 // indirect
-+	github.com/hashicorp/hc-install v0.3.1 // indirect
-+	github.com/hashicorp/hcl v1.0.0 // indirect
-+	github.com/hashicorp/hcl/v2 v2.11.1 // indirect
-+	github.com/hashicorp/logutils v1.0.0 // indirect
-+	github.com/hashicorp/terraform-exec v0.16.1 // indirect
-+	github.com/hashicorp/terraform-json v0.13.0 // indirect
-+	github.com/hashicorp/terraform-plugin-go v0.9.0 // indirect
-+	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
-+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
-+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-+	github.com/kisielk/gotool v1.0.0 // indirect
-+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
-+	github.com/magiconair/properties v1.8.1 // indirect
-+	github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb // indirect
-+	github.com/mattn/go-colorable v0.1.4 // indirect
-+	github.com/mattn/go-isatty v0.0.10 // indirect
-+	github.com/mitchellh/copystructure v1.2.0 // indirect
-+	github.com/mitchellh/go-homedir v1.1.0 // indirect
-+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
-+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-+	github.com/mitchellh/mapstructure v1.4.3 // indirect
-+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-+	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
-+	github.com/oklog/run v1.0.0 // indirect
-+	github.com/pelletier/go-toml v1.2.0 // indirect
-+	github.com/pmezard/go-difflib v1.0.0 // indirect
-+	github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d // indirect
-+	github.com/sirupsen/logrus v1.4.2 // indirect
-+	github.com/sourcegraph/go-diff v0.5.1 // indirect
-+	github.com/spf13/afero v1.2.2 // indirect
-+	github.com/spf13/cast v1.3.0 // indirect
-+	github.com/spf13/cobra v0.0.5 // indirect
-+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
-+	github.com/spf13/pflag v1.0.5 // indirect
-+	github.com/spf13/viper v1.7.0 // indirect
-+	github.com/stretchr/objx v0.2.0 // indirect
-+	github.com/stretchr/testify v1.7.0 // indirect
-+	github.com/subosito/gotenv v1.2.0 // indirect
-+	github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e // indirect
-+	github.com/ultraware/funlen v0.0.2 // indirect
-+	github.com/ultraware/whitespace v0.0.4 // indirect
-+	github.com/uudashr/gocognit v0.0.0-20190926065955-1655d0de0517 // indirect
-+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
-+	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
-+	github.com/vmihailenco/tagparser v0.1.1 // indirect
-+	github.com/zclconf/go-cty v1.10.0 // indirect
-+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-+	golang.org/x/mod v0.3.0 // indirect
-+	golang.org/x/net v0.0.0-20210326060303-6b1517762897 // indirect
-+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
-+	golang.org/x/text v0.3.5 // indirect
- 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb // indirect
-+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-+	google.golang.org/appengine v1.6.6 // indirect
- 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
-+	google.golang.org/grpc v1.45.0 // indirect
-+	google.golang.org/protobuf v1.28.0 // indirect
-+	gopkg.in/ini.v1 v1.51.0 // indirect
-+	gopkg.in/yaml.v2 v2.4.0 // indirect
-+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
- 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
--	software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-+	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
-+	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
-+	mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f // indirect
-+	sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4 // indirect
- )
-diff --git b/go.sum a/go.sum
-index 700bb7d..4d2c86d 100644
---- b/go.sum
-+++ a/go.sum
-@@ -32,14 +32,10 @@ github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXva
- github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
- github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
- github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
--github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
- github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
- github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
--github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
- github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
- github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
--github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
--github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
- github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
- github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
- github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
-@@ -48,7 +44,6 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
- github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
- github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
- github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
--github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
- github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
- github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
- github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-@@ -94,12 +89,10 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
- github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
- github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
- github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
--github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
- github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
- github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
- github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
- github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
--github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
- github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
- github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db h1:GYXWx7Vr3+zv833u+8IoXbNnQY0AdXsxAgI0kX7xcwA=
- github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db/go.mod h1:+sE8vrLDS2M0pZkBk0wy6+nLdKexVDrl/jBqQOTDThA=
-@@ -108,7 +101,6 @@ github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4u
- github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
- github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
- github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
--github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
- github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
- github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
- github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
-@@ -334,7 +326,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
- github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
- github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
- github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
--github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
- github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
- github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
- github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-@@ -342,7 +333,6 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
- github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
- github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb h1:RHba4YImhrUVQDHUCe2BNSOz4tVy2yGyXhvYDvxGgeE=
- github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
--github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
- github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
- github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
- github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
-@@ -384,7 +374,6 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1
- github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
- github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
- github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
--github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
- github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
- github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
- github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-@@ -428,7 +417,6 @@ github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d/go.mod h1:w5+eXa0mY
- github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
- github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
- github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
--github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
- github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
- github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
- github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt3d2aYa0SiNms/hFqC9qJYolM=
-@@ -506,7 +494,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
- github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
- github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a h1:fZHgsYlfvtyqToslyjUt3VOPF4J7aK/3MPcK7xp3PDk=
- github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a/go.mod h1:ul22v+Nro/R083muKhosV54bj5niojjWZvU8xrevuH4=
--github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
- github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
- github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
- github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-@@ -581,7 +568,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
- golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
- golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
- golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
--golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
- golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
- golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
- golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-@@ -597,7 +583,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
- golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
--golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
- golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
- golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-@@ -669,7 +654,6 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
- golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
- golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
- golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
--golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
- golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb h1:KVWk3RW1AZlxWum4tYqegLgwJHb5oouozcGM8HfNQaw=
- golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
- golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -701,7 +685,6 @@ google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBr
- google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
- google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
- google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
--google.golang.org/genproto v0.0.0-20200711021454-869866162049/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
- google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d h1:92D1fum1bJLKSdr11OJ+54YeCMCGYIygTA7R/YZxH5M=
- google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
- google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
-@@ -717,7 +700,6 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
- google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
- google.golang.org/grpc v1.45.0 h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=
- google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
--google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
- google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
- google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
- google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
-@@ -730,7 +712,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
- google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
- google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
- google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
--google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
- google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
- google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
- gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-diff --git b/main.go a/main.go
+diff --git a/main.go b/main.go
 index 13942e8..7a7e9ad 100644
---- b/main.go
-+++ a/main.go
+--- a/main.go
++++ b/main.go
 @@ -2,9 +2,10 @@ package main
  
  import (
@@ -288,10 +39,10 @@ index 13942e8..7a7e9ad 100644
  )
  
  func main() {
-diff --git b/website/docs/r/venafi_certificate.html.markdown a/website/docs/r/venafi_certificate.html.markdown
+diff --git a/website/docs/r/venafi_certificate.html.markdown b/website/docs/r/venafi_certificate.html.markdown
 index 34314a6..617acc7 100644
---- b/website/docs/r/venafi_certificate.html.markdown
-+++ a/website/docs/r/venafi_certificate.html.markdown
+--- a/website/docs/r/venafi_certificate.html.markdown
++++ b/website/docs/r/venafi_certificate.html.markdown
 @@ -15,6 +15,11 @@ For backward compatibility during Terraform state refresh please update to versi
  Provides access to TLS key and certificate data enrolled using Venafi. This can be used to define a
  certificate.
@@ -370,3 +121,6 @@ index 34314a6..617acc7 100644
 -```sh
 -terraform import "venafi_certificate.imported_certificate" "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,my_key_password"
 -```
+-- 
+2.42.0
+

--- a/patches/0002-Docs-changes-to-venafi_certificate.patch
+++ b/patches/0002-Docs-changes-to-venafi_certificate.patch
@@ -1,44 +1,12 @@
-From fde17ddbef7d562d74211b1406c286041863f30a Mon Sep 17 00:00:00 2001
+From 0f3faf7d2d0bf222094d18905051fa8816fcab21 Mon Sep 17 00:00:00 2001
 From: Ian Wahbe <ian@wahbe.com>
-Date: Tue, 3 Oct 2023 12:15:12 -0700
-Subject: [PATCH] Fix import path
+Date: Tue, 3 Oct 2023 12:21:45 -0700
+Subject: [PATCH 2/2] Docs changes to venafi_certificate
 
 ---
- go.mod                                        |  4 +-
- main.go                                       |  5 +-
  .../docs/r/venafi_certificate.html.markdown   | 56 +++----------------
- 3 files changed, 14 insertions(+), 51 deletions(-)
+ 1 file changed, 9 insertions(+), 47 deletions(-)
 
-diff --git a/go.mod b/go.mod
-index 0324614..05168b8 100644
---- a/go.mod
-+++ b/go.mod
-@@ -1,6 +1,6 @@
--module github.com/terraform-providers/terraform-provider-venafi
-+module github.com/Venafi/terraform-provider-venafi
- 
--go 1.12
-+go 1.19
- 
- require (
- 	github.com/Venafi/vcert/v4 v4.22.0
-diff --git a/main.go b/main.go
-index 13942e8..7a7e9ad 100644
---- a/main.go
-+++ b/main.go
-@@ -2,9 +2,10 @@ package main
- 
- import (
- 	"flag"
--	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
--	"github.com/terraform-providers/terraform-provider-venafi/venafi"
- 	"log"
-+
-+	"github.com/Venafi/terraform-provider-venafi/venafi"
-+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
- )
- 
- func main() {
 diff --git a/website/docs/r/venafi_certificate.html.markdown b/website/docs/r/venafi_certificate.html.markdown
 index 34314a6..617acc7 100644
 --- a/website/docs/r/venafi_certificate.html.markdown


### PR DESCRIPTION
This cleans up the patch so it applies cleanly during upgrades. This is purely a refactor.

This PR also disables integration tests to unblock updates. We will re-enable integration tests when we get a new auth token.