### PR TITLE
Re-enable integration tests

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -33,7 +33,6 @@ func getCwd(t *testing.T) string {
 }
 
 func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
-	t.Skip("Skipping due to expired Venafi token")
 	return integration.ProgramTestOptions{
 		ExpectRefreshChanges: true,
 		Secrets: map[string]string{


### PR DESCRIPTION
I have worked with Venafi to get our VaaS tenant extended to EOY. This should allow us re-enable our integration tests.